### PR TITLE
Add delay for TFT

### DIFF
--- a/esp8266-weather-station-color.ino
+++ b/esp8266-weather-station-color.ino
@@ -163,7 +163,7 @@ void setup() {
   pinMode(TFT_LED, OUTPUT);
   digitalWrite(TFT_LED, HIGH);    // HIGH to Turn on;
 
-  
+  delay(100); 
   gfx.init();
   gfx.fillBuffer(MINI_BLACK);
   gfx.commit();
@@ -651,4 +651,3 @@ String getTime(time_t *timestamp) {
   sprintf(buf, "%02d:%02d", timeInfo->tm_hour, timeInfo->tm_min);
   return String(buf);
 }
-


### PR DESCRIPTION
For some reason, sketch needs a small delay so TFT will work on initial power.
https://forums.adafruit.com/viewtopic.php?f=25&t=145423#p718915
https://forums.adafruit.com/viewtopic.php?f=57&t=134255#p696260

Without delay:
![without_delay](https://user-images.githubusercontent.com/8755041/50711542-6374a780-1023-11e9-915b-61219526d337.jpg)
With delay:
![with_delay](https://user-images.githubusercontent.com/8755041/50711553-6cfe0f80-1023-11e9-9277-1b467dc211b5.jpg)


